### PR TITLE
Remove 2 year option 177628351

### DIFF
--- a/src/components/hazard/map/legend/constants.js
+++ b/src/components/hazard/map/legend/constants.js
@@ -1,5 +1,4 @@
 export const RETURN_PERIOD_OPTIONS = [
-  { label: '2', value: '0002' },
   { label: '5', value: '0005' },
   { label: '10', value: '0010' },
   { label: '25', value: '0025' },
@@ -10,7 +9,7 @@ export const RETURN_PERIOD_OPTIONS = [
   { label: '1000', value: '1000' }
 ]
 
-export const RANGE_LABELS = ['>0', '2', '5', '7', '10', '20', '>=50'];
+export const RANGE_LABELS = ['>0', '5', '7', '10', '20', '>=50'];
 
 export default {
   RETURN_PERIOD_OPTIONS,

--- a/src/components/ui/map/legend/component.js
+++ b/src/components/ui/map/legend/component.js
@@ -10,6 +10,7 @@ import {
 
 // styles
 import './styles.scss';
+import { RETURN_PERIOD_OPTIONS } from 'components/hazard/map/legend/constants';
 
 class HazardLegend extends PureComponent {
   static propTypes = {

--- a/src/components/ui/map/legend/component.js
+++ b/src/components/ui/map/legend/component.js
@@ -10,7 +10,6 @@ import {
 
 // styles
 import './styles.scss';
-import { RETURN_PERIOD_OPTIONS } from 'components/hazard/map/legend/constants';
 
 class HazardLegend extends PureComponent {
   static propTypes = {

--- a/src/components/ui/map/legend/constants.js
+++ b/src/components/ui/map/legend/constants.js
@@ -1,5 +1,4 @@
 export const RETURN_PERIOD_OPTIONS = [
-  { label: '2', value: '0002' },
   { label: '5', value: '0005' },
   { label: '10', value: '0010' },
   { label: '25', value: '0025' },
@@ -17,7 +16,6 @@ RETURN_PERIOD_OPTIONS.forEach((opt) => {
 });
 
 export const PROBABILITY_CONVERSION = {
-  2: '0.5',
   5: '0.2',
   10: '0.1',
   25: '0.04',


### PR DESCRIPTION
I poked around a bit. It looks like the constants I removed the two-year option from are only used on the HazardLegend component. The image below is from a throwaway branch off of fix-api-calls with this branch merged in: 
![image](https://user-images.githubusercontent.com/21186402/119152926-fd2f2a80-ba0d-11eb-8265-4fc6ebe9225f.png)
